### PR TITLE
Add per-character callback function

### DIFF
--- a/include/attentive/at.h
+++ b/include/attentive/at.h
@@ -82,6 +82,14 @@ void at_set_callbacks(struct at *at, const struct at_callbacks *cbs, void *arg);
 void at_set_command_scanner(struct at *at, at_line_scanner_t scanner);
 
 /**
+ * Set custom per-character handler for the next command.
+ *
+ * @param at AT channel instance.
+ * @param handler Character handler.
+ */
+void at_set_character_handler(struct at *at, at_character_handler_t handler);
+
+/**
  * Expect "> " dataprompt as a response for the next command.
  *
  * @param at AT channel instance.

--- a/include/attentive/parser.h
+++ b/include/attentive/parser.h
@@ -45,6 +45,9 @@ enum at_response_type {
 /** @internal */
 #define _AT_RESPONSE_TYPE_MASK 0xff
 
+/** Per-character handler. */
+typedef char (*at_character_handler_t)(char ch, char *line, size_t len, void *priv);
+
 /** Line scanner. Should return one of the AT_RESPONSE_* values if the line is
  *  identified or AT_RESPONSE_UNKNOWN to fall back to the default scanner. */
 typedef enum at_response_type (*at_line_scanner_t)(const char *line, size_t len, void *priv);
@@ -62,6 +65,7 @@ enum at_parser_state {
 
 struct at_parser {
     const struct at_parser_callbacks *cbs;
+    at_character_handler_t character_handler;
     void *priv;
 
     enum at_parser_state state;
@@ -112,6 +116,14 @@ void at_parser_init(struct at_parser *parser, const struct at_parser_callbacks *
  * @param parser Parser instance.
  */
 void at_parser_reset(struct at_parser *parser);
+
+/**
+ * Make the parser handle each character received.
+ *
+ * @param parser Parser instance.
+ * @param handler Character handler.
+ */
+void at_parser_set_character_handler(struct at_parser *parser, at_character_handler_t handler);
 
 /**
  * Make the parser expect a dataprompt for the next command.

--- a/src/parser.c
+++ b/src/parser.c
@@ -71,6 +71,12 @@ void at_parser_reset(struct at_parser *parser)
     parser->buf_used = 0;
     parser->buf_current = 0;
     parser->data_left = 0;
+    parser->character_handler = NULL;
+}
+
+void at_parser_set_character_handler(struct at_parser *parser, at_character_handler_t handler)
+{
+    parser->character_handler = handler;
 }
 
 void at_parser_expect_dataprompt(struct at_parser *parser)
@@ -260,6 +266,13 @@ void at_parser_feed(struct at_parser *parser, const void *data, size_t len)
                 if ((ch != '\r') && (ch != '\n')) {
                     /* Append the character if it's not a newline. */
                     parser_append(parser, ch);
+                }
+
+                /* Handle a single character. */
+                if (parser->character_handler) {
+                    ch = parser->character_handler(ch, parser->buf + parser->buf_current,
+                                                    parser->buf_used - parser->buf_current,
+                                                    parser->priv);
                 }
 
                 /* Handle full lines. */

--- a/src/parser.c
+++ b/src/parser.c
@@ -263,16 +263,16 @@ void at_parser_feed(struct at_parser *parser, const void *data, size_t len)
             case STATE_READLINE:
             case STATE_DATAPROMPT:
             {
-                if ((ch != '\r') && (ch != '\n')) {
-                    /* Append the character if it's not a newline. */
-                    parser_append(parser, ch);
-                }
-
                 /* Handle a single character. */
                 if (parser->character_handler) {
                     ch = parser->character_handler(ch, parser->buf + parser->buf_current,
                                                     parser->buf_used - parser->buf_current,
                                                     parser->priv);
+                }
+
+                if ((ch != '\r') && (ch != '\n')) {
+                    /* Append the character if it's not a newline. */
+                    parser_append(parser, ch);
                 }
 
                 /* Handle full lines. */


### PR DESCRIPTION
This will be used to deal with Cavli sockets where the socket payload is a part of the socket data notification URC and when there's no newline delimiter between the metadata and payload:

`+CIPBREAD: <size>,<payload>`