### PR TITLE
Possible fix for the response/URC problem

### DIFF
--- a/include/attentive/parser.h
+++ b/include/attentive/parser.h
@@ -61,6 +61,7 @@ enum at_parser_state {
     STATE_DATAPROMPT,
     STATE_RAWDATA,
     STATE_HEXDATA,
+    STATE_RESPONSE_PENDING,
 };
 
 struct at_parser {
@@ -168,6 +169,18 @@ void at_parser_free(struct at_parser *parser);
  * @returns True if found, false otherwise.
  */
 bool at_prefix_in_table(const char *line, const char *const table[]);
+
+/**
+ * Release a pending response buffer.
+ *
+ * After a command completes, the parser enters STATE_RESPONSE_PENDING to keep
+ * the response buffer stable while the caller processes it. URCs received
+ * during this time are handled normally using buffer space after the response.
+ * Call this function when done processing the response to reset the parser.
+ *
+ * @param parser Parser instance.
+ */
+void at_parser_release_response(struct at_parser *parser);
 
 #if defined(__cplusplus)
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -86,6 +86,10 @@ void at_parser_expect_dataprompt(struct at_parser *parser)
 
 void at_parser_await_response(struct at_parser *parser)
 {
+    /* Release any pending response before starting a new command. */
+    if (parser->state == STATE_RESPONSE_PENDING)
+        at_parser_reset(parser);
+
     parser->state = (parser->expect_dataprompt ? STATE_DATAPROMPT : STATE_READLINE);
 }
 
@@ -176,7 +180,8 @@ static void parser_handle_line(struct at_parser *parser)
         type = generic_line_scanner(line, len, parser);
 
     /* Expected URCs and all unexpected lines are sent to URC handler. */
-    if (type == AT_RESPONSE_URC || parser->state == STATE_IDLE)
+    if (type == AT_RESPONSE_URC || parser->state == STATE_IDLE ||
+        parser->state == STATE_RESPONSE_PENDING)
     {
         /* Fire the callback on the URC line. */
         parser->cbs->handle_urc(parser->buf + parser->buf_current,
@@ -207,8 +212,11 @@ static void parser_handle_line(struct at_parser *parser)
             parser_finalize(parser);
             parser->cbs->handle_response(parser->buf, parser->buf_used, parser->priv);
 
-            /* Go back to idle state. */
-            at_parser_reset(parser);
+            /* Enter pending state - response buffer remains stable until released.
+             * URCs will use buffer space after the response. */
+            parser->buf_current = parser->buf_used + 1;
+            parser->buf_used = parser->buf_current;
+            parser->state = STATE_RESPONSE_PENDING;
         }
         break;
 
@@ -259,6 +267,7 @@ void at_parser_feed(struct at_parser *parser, const void *data, size_t len)
 
         switch (parser->state)
         {
+            case STATE_RESPONSE_PENDING:
             case STATE_IDLE:
             case STATE_READLINE:
             case STATE_DATAPROMPT:
@@ -326,6 +335,14 @@ void at_parser_free(struct at_parser *parser)
 {
     free(parser->buf);
     free(parser);
+}
+
+void at_parser_release_response(struct at_parser *parser)
+{
+    if (parser->state == STATE_RESPONSE_PENDING)
+    {
+        at_parser_reset(parser);
+    }
 }
 
 /* vim: set ts=4 sw=4 et: */

--- a/src/parser.c
+++ b/src/parser.c
@@ -223,6 +223,7 @@ static void parser_handle_line(struct at_parser *parser)
             parser->buf_current = parser->buf_used + 1;
             parser->buf_used = parser->buf_current;
             parser->state = STATE_RESPONSE_PENDING;
+            parser->expect_dataprompt = false;
         }
         break;
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -345,7 +345,13 @@ void at_parser_release_response(struct at_parser *parser)
 {
     if (parser->state == STATE_RESPONSE_PENDING)
     {
+        /* Move any pending data to the start of the buffer. */
+        size_t pending = parser->buf_used - parser->buf_current;
+        if (pending > 0)
+            memmove(parser->buf, parser->buf + parser->buf_current, pending);
+
         at_parser_reset(parser);
+        parser->buf_used = pending;
     }
 }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -86,9 +86,15 @@ void at_parser_expect_dataprompt(struct at_parser *parser)
 
 void at_parser_await_response(struct at_parser *parser)
 {
-    /* Release any pending response before starting a new command. */
+    /* Release any pending response before starting a new command.
+     * Preserve expect_dataprompt as it may have been set by the caller
+     * before this function was invoked. */
     if (parser->state == STATE_RESPONSE_PENDING)
+    {
+        bool expect_dataprompt = parser->expect_dataprompt;
         at_parser_reset(parser);
+        parser->expect_dataprompt = expect_dataprompt;
+    }
 
     parser->state = (parser->expect_dataprompt ? STATE_DATAPROMPT : STATE_READLINE);
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -86,17 +86,14 @@ void at_parser_expect_dataprompt(struct at_parser *parser)
 
 void at_parser_await_response(struct at_parser *parser)
 {
-    /* Release any pending response before starting a new command.
-     * Preserve expect_dataprompt as it may have been set by the caller
-     * before this function was invoked. */
-    if (parser->state == STATE_RESPONSE_PENDING)
-    {
-        bool expect_dataprompt = parser->expect_dataprompt;
-        at_parser_reset(parser);
-        parser->expect_dataprompt = expect_dataprompt;
-    }
+    /* Preserve expect_dataprompt as it may have been set before this call. */
+    bool expect_dataprompt = parser->expect_dataprompt;
 
-    parser->state = (parser->expect_dataprompt ? STATE_DATAPROMPT : STATE_READLINE);
+    /* Release any pending response before starting a new command. */
+    at_parser_release_response(parser);
+
+    parser->expect_dataprompt = expect_dataprompt;
+    parser->state = (expect_dataprompt ? STATE_DATAPROMPT : STATE_READLINE);
 }
 
 bool at_prefix_in_table(const char *line, const char *const table[])

--- a/tests/test-parser.c
+++ b/tests/test-parser.c
@@ -304,11 +304,48 @@ START_TEST(test_parser_dataprompt)
 }
 END_TEST
 
+static const char *response_buf_ptr;
+
+static void capture_response(const char *buf, size_t len, void *priv)
+{
+    (void) priv;
+    (void) len;
+    response_buf_ptr = buf;
+}
+
+static void ignore_urc(const char *buf, size_t len, void *priv)
+{
+    (void) priv;
+    (void) buf;
+    (void) len;
+}
+
+START_TEST(test_parser_urc_does_not_overwrite_response)
+{
+    printf(":: test_parser_urc_does_not_overwrite_response\n");
+
+    struct at_parser_callbacks cbs = {
+        .handle_response = capture_response,
+        .handle_urc = ignore_urc,
+    };
+    struct at_parser *parser = at_parser_alloc(&cbs, 256, NULL);
+
+    at_parser_await_response(parser);
+    at_parser_feed(parser, STR_LEN("data\r\nOK\r\n"));
+    ck_assert_str_eq(response_buf_ptr, "data");
+
+    at_parser_feed(parser, STR_LEN("RING\r\n"));
+    ck_assert_str_eq(response_buf_ptr, "data");  /* Must not be overwritten */
+
+    at_parser_free(parser);
+}
+END_TEST
+
 Suite *attentive_suite(void)
 {
     Suite *s = suite_create("attentive");
     TCase *tc;
-  
+
     tc = tcase_create("parser");
     tcase_add_test(tc, test_parser_alloc);
     tcase_add_test(tc, test_parser_response);
@@ -318,6 +355,7 @@ Suite *attentive_suite(void)
     tcase_add_test(tc, test_parser_rawdata);
     tcase_add_test(tc, test_parser_hexdata);
     tcase_add_test(tc, test_parser_dataprompt);
+    tcase_add_test(tc, test_parser_urc_does_not_overwrite_response);
     suite_add_tcase(s, tc);
 
     return s;


### PR DESCRIPTION
Previously after sending a command the parser would go back to the IDLE state. If a URC arrives before the response has been processed the parser will start overwriting it.
While we're waiting for the response to be handled, append URCs to the buffer available past the response.